### PR TITLE
Fix passing buffer bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ function anyify(file, opts) {
 		var transformFn = createTransform(name);
 		return unstream(function(data, callback) {
 			try {
-				callback(null, transformFn(data, opts));
+				callback(null, transformFn(data.toString(), opts));
 			} catch(e) {
 				callback(e);
 			}


### PR DESCRIPTION
LiveScript compile is not works.

```
% browserify -t [ anyify --ls [ livescript?compile ] ]
```

Because `anyify` passing buffer object to compile function. This PR is fix this bug.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/quarterto/anyify/3)
<!-- Reviewable:end -->
